### PR TITLE
docs(mkdocs.yml): correct the link to the github repo

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,7 @@ site_name: Industrial MLLM Benchmark
 site_description: Industrial MLLM Benchmark
 site_author: Dieter Bogdoll <dieter.bogdoll@siemens.com>, Markus Geipel <markus.geipel@siemens.com>
 
-repo_url: https://github.com/siemens-research/industrial_mllm_benchmark.git
+repo_url: https://github.com/siemens-research/industrial-mllm-benchmark.git
 edit_uri: tree/main/docs
 
 copyright: "Copyright &copy; 2024 Siemens AG"


### PR DESCRIPTION
The link from the mkdocs page to the github repo is broken (replace '_' with '-')